### PR TITLE
Enhance uploader behavior and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,19 @@ import { ImageUploader } from 'image-lib';
 <ImageUploader
   multiple
   process
+  includeOriginal={false}
   onComplete={(images) => console.log(images)}
 />;
 ```
 
-The `onComplete` callback receives the processed image blobs so you can handle the actual upload.
+Set `multiple` to allow selecting more than one image. When enabled you can pick
+additional files at any time and they are appended to the list instead of
+replacing the previous selection. Use `includeOriginal` if you need the original
+file alongside processed versions.
+
+The `onComplete` callback receives the processed image blobs so you can handle
+the actual upload. Thumbnails are displayed with a small remove button and the
+file picker stays on the left so you can add more images. If the container has a
+fixed height the list becomes vertically scrollable.
 
 Run `npm run dev` to start the demo application.

--- a/src/components/ImageUploader.css
+++ b/src/components/ImageUploader.css
@@ -1,14 +1,68 @@
+.image-uploader {
+  max-height: 100%;
+  overflow-y: auto;
+}
+
 .image-uploader .preview-list {
   display: flex;
+  flex-wrap: wrap;
   gap: 0.5rem;
   margin-top: 0.5rem;
 }
-.image-uploader .preview {
+
+.image-uploader .upload-btn {
   width: 80px;
   height: 80px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #f7f7f7;
+  color: #555;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.image-uploader .upload-btn input {
+  display: none;
+}
+.image-uploader .upload-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.image-uploader .preview-container {
+  position: relative;
+  width: 80px;
+  height: 80px;
+}
+
+.image-uploader .preview {
+  width: 100%;
+  height: 100%;
   object-fit: cover;
   border-radius: 4px;
 }
-.image-uploader .progress {
+
+.image-uploader .remove-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  font-size: 12px;
+  line-height: 16px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.image-uploader .upload-status {
   margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }

--- a/src/utils/imageProcessor.ts
+++ b/src/utils/imageProcessor.ts
@@ -13,6 +13,7 @@ export interface ProcessedImage {
 export interface ProcessOptions {
   sizes?: SizeOption[];
   process?: boolean;
+  includeOriginal?: boolean;
   signal?: AbortSignal;
   onProgress?: (percentage: number) => void;
 }
@@ -39,16 +40,20 @@ async function compressImage(file: File, sizes: SizeOption[]): Promise<Processed
 }
 
 export async function processFiles(files: File[], options: ProcessOptions): Promise<ProcessedImage[][]> {
-  const { process = true, sizes = [], onProgress, signal } = options;
+  const { process = true, sizes = [], includeOriginal = false, onProgress, signal } = options;
   const results: ProcessedImage[][] = [];
   const total = files.length;
   let done = 0;
 
   for (const file of files) {
     if (signal?.aborted) break;
-    const processed = process && sizes.length
-      ? await compressImage(file, sizes)
-      : [{ name: file.name, blob: file }];
+    const processed: ProcessedImage[] = [];
+    if (process && sizes.length) {
+      processed.push(...(await compressImage(file, sizes)));
+    }
+    if (!process || includeOriginal || processed.length === 0) {
+      processed.push({ name: file.name, blob: file });
+    }
 
     results.push(processed);
     done += 1;


### PR DESCRIPTION
## Summary
- allow storing original files via new `includeOriginal` option
- make uploader append files when multiple selections are made
- add ability to remove previews and cancel ongoing work
- tweak layout/styles and show iconized upload button
- document new props in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6864f765a064832fa7eb4a40dfa592d7